### PR TITLE
Update Codex sidebar rename patcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 node_modules/
 .vscode/
 .idea/
+.codex/
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.1.1 - 2026-05-15
+
+Compatibility update for newer `openai.chatgpt` extension builds.
+
+### Added
+
+- Verification now scans all webview JavaScript bundles instead of only the primary `index-*.js` bundle.
+- Verification now excludes the injected helper bundle and checks the OpenAI webview's built-in thread rename signature.
+- Webview helper now supports newer `data-app-action-sidebar-thread-*` thread row/title attributes.
+- Inline rename flow and `Cmd+R` / `Ctrl+R` rename shortcut support.
+- Context-aware `Rename Thread` contribution for the original VS Code webview menu.
+
+### Fixed
+
+- Canceling rename input now exits silently instead of showing an error toast.
+- Live title updates now patch both older `data-thread-title` nodes and newer sidebar title nodes.
+- Right-click rename no longer replaces the original menu; it marks the selected row and uses the native menu item above `New Thread`.
+- The Command Palette rename flow now starts inline rename for the current thread when one is active, and falls back to the thread picker outside a thread.
+
 ## 0.1.0 - 2026-02-22
 
 Initial working patcher release for adding live Codex thread rename support to the VS Code `openai.chatgpt` extension.
@@ -22,9 +41,6 @@ Initial working patcher release for adding live Codex thread rename support to t
 - Injected webview helper (`webview/assets/codex-thread-renamer.patch.webview.js`) that:
   - adds right-click `Rename Thread` on Codex thread titles
   - forwards rename requests through `open-vscode-command`
-- `.context` wrapper script for reapplying the patch after extension updates:
-  - `.context/scripts/apply-codex-thread-renamer-patch.sh`
-
 ### Fixed During Development
 
 - Webview bootstrap breakage caused by eager `acquireVsCodeApi()` usage in the helper
@@ -33,9 +49,3 @@ Initial working patcher release for adding live Codex thread rename support to t
   - fixed from nested `menus.webview.context` to literal `menus[\"webview/context\"]`
 - Runtime command registration reliability
   - command now registers early so the contributed menu item resolves at runtime
-
-### Known Issues
-
-- Canceling the rename prompt currently shows an error toast:
-  - `Codex rename patch: Rename cancelled.`
-  - Expected future behavior: silent cancel with no error toast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Compatibility update for newer `openai.chatgpt` extension builds.
 
 - Canceling rename input now exits silently instead of showing an error toast.
 - Live title updates now patch both older `data-thread-title` nodes and newer sidebar title nodes.
-- Right-click rename no longer replaces the original menu; it marks the selected row and uses the native menu item above `New Thread`.
+- Right-click rename no longer replaces the original menu; the native menu now keeps `Rename Thread in Codex Sidebar` above `New Thread in Codex Sidebar`.
+- Sidebar right-clicks outside a thread row now show both Codex sidebar actions.
 - The Command Palette rename flow now starts inline rename for the current thread when one is active, and falls back to the thread picker outside a thread.
 
 ## 0.1.0 - 2026-02-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Compatibility update for newer `openai.chatgpt` extension builds.
 - Verification now excludes the injected helper bundle and checks the OpenAI webview's built-in thread rename signature.
 - Webview helper now supports newer `data-app-action-sidebar-thread-*` thread row/title attributes.
 - Inline rename flow and `Cmd+R` / `Ctrl+R` rename shortcut support.
-- Context-aware `Rename Thread` contribution for the original VS Code webview menu.
+- Context-aware `Rename Thread in Codex Sidebar` contribution for the original VS Code webview menu.
 
 ### Fixed
 
@@ -40,7 +40,7 @@ Initial working patcher release for adding live Codex thread rename support to t
   - patches workspace/global/Codex title caches
   - sends live `thread-title-updated` messages to Codex webviews
 - Injected webview helper (`webview/assets/codex-thread-renamer.patch.webview.js`) that:
-  - adds right-click `Rename Thread` on Codex thread titles
+  - adds right-click `Rename Thread in Codex Sidebar` on Codex thread titles
   - forwards rename requests through `open-vscode-command`
 ### Fixed During Development
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Use `verify` before `apply`, and reapply after updating the OpenAI extension.
 ## What It Adds
 
 - `Rename Codex Thread` command in the Command Palette
-- Right-click `Rename Thread` action in the Codex thread list
+- `Rename Thread` added to the original Codex thread right-click menu above `New Thread`
+- Inline title editing for the selected or current Codex thread
+- `Cmd+R` / `Ctrl+R` rename shortcut for Codex sidebar and conversation editor contexts
 - Live title updates in the open Codex UI
 - Persistent rename via Codex backend rename RPC
 - Cache patching fallback so stale titles do not come back
@@ -73,8 +75,10 @@ After patching and reloading VS Code:
 
 1. Open the Codex sidebar.
 2. Rename a thread using either:
-   - Command Palette -> `Rename Codex Thread`
+   - Command Palette -> `Rename Codex Thread` while inside a thread to rename the current thread inline
+   - Command Palette -> `Rename Codex Thread` outside a thread to choose from the thread list
    - Right-click a thread title -> `Rename Thread`
+   - `Cmd+R` / `Ctrl+R` when the Codex sidebar or conversation editor is active
 
 ## Commands
 
@@ -92,15 +96,6 @@ Optional flags:
 - [Technical internals](docs/how-it-works.md)
 - [Testing and troubleshooting](docs/testing-and-troubleshooting.md)
 - [Release history](CHANGELOG.md)
-
-## Known Issue
-
-- Canceling the rename prompt currently shows:
-  - `Codex rename patch: Rename cancelled.`
-- This is a UX issue only.
-- Tracked in:
-  - [Issue #1](https://github.com/Just-Boring-Cat/codex-thread-renamer/issues/1)
-  - [CHANGELOG.md](CHANGELOG.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Use `verify` before `apply`, and reapply after updating the OpenAI extension.
 ## What It Adds
 
 - `Rename Codex Thread` command in the Command Palette
-- `Rename Thread` added to the original Codex thread right-click menu above `New Thread`
+- `Rename Thread in Codex Sidebar` added to the original Codex sidebar right-click menu, directly above `New Thread in Codex Sidebar`
 - Inline title editing for the selected or current Codex thread
 - `Cmd+R` / `Ctrl+R` rename shortcut for Codex sidebar and conversation editor contexts
 - Live title updates in the open Codex UI
@@ -77,7 +77,7 @@ After patching and reloading VS Code:
 2. Rename a thread using either:
    - Command Palette -> `Rename Codex Thread` while inside a thread to rename the current thread inline
    - Command Palette -> `Rename Codex Thread` outside a thread to choose from the thread list
-   - Right-click a thread title -> `Rename Thread`
+   - Right-click the Codex sidebar -> `Rename Thread in Codex Sidebar`
    - `Cmd+R` / `Ctrl+R` when the Codex sidebar or conversation editor is active
 
 ## Commands

--- a/bin/codex-thread-renamer-patch.js
+++ b/bin/codex-thread-renamer-patch.js
@@ -234,7 +234,7 @@ function patchPackageJson(file, dryRun, logs) {
   });
   upsertCommand(pkg.contributes.commands, {
     command: 'chatgpt.renameThreadInline',
-    title: 'Rename Thread',
+    title: 'Rename Thread in Codex Sidebar',
     category: 'Codex',
   });
   upsertCommand(pkg.contributes.commands, {
@@ -255,6 +255,7 @@ function patchPackageJson(file, dryRun, logs) {
     command: 'chatgpt.renameThreadRememberContext',
     when: 'false',
   });
+  removeMenuItem(commandPalette, 'chatgpt.renameThreadFromMenu');
 
   upsertKeybinding(pkg.contributes.keybindings, {
     command: 'chatgpt.renameThreadInline',
@@ -269,11 +270,13 @@ function patchPackageJson(file, dryRun, logs) {
   upsertMenuItem(webviewContext, {
     command: 'chatgpt.renameThreadInline',
     when: "(webviewId == 'chatgpt.sidebarView' || webviewId == 'chatgpt.sidebarSecondaryView') && codexThreadRenamer == 'thread'",
-    group: 'navigation@1',
+    group: 'z_codexThreadActions@1',
   });
   preserveNewThreadMenuItem(webviewContext);
   moveMenuItemBefore(webviewContext, 'chatgpt.renameThreadInline', 'chatgpt.newChat');
   removeMenuItem(webviewContext, 'chatgpt.renameThread');
+  removeMenuItem(webviewContext, 'chatgpt.renameThreadFromMenu');
+  removeCommand(pkg.contributes.commands, 'chatgpt.renameThreadFromMenu');
 
   const updated = JSON.stringify(pkg, null, 2) + '\n';
   writeIfChanged(file, raw, updated, dryRun, logs);
@@ -304,6 +307,14 @@ function upsertCommand(commands, command) {
   }
 }
 
+function removeCommand(commands, command) {
+  for (let i = commands.length - 1; i >= 0; i--) {
+    if (commands[i] && commands[i].command === command) {
+      commands.splice(i, 1);
+    }
+  }
+}
+
 function upsertKeybinding(keybindings, keybinding) {
   const idx = keybindings.findIndex((entry) => entry && entry.command === keybinding.command);
   if (idx >= 0) {
@@ -331,13 +342,13 @@ function upsertMenuItem(menuItems, menuItem) {
 }
 
 function preserveNewThreadMenuItem(menuItems) {
-  const newThreadWhen = "(webviewId == 'chatgpt.sidebarView' || webviewId == 'chatgpt.sidebarSecondaryView') && chatgpt.supportsNewChatMenu";
+  const newThreadWhen = "(webviewId == 'chatgpt.sidebarView' || webviewId == 'chatgpt.sidebarSecondaryView') && codexThreadRenamer == 'thread'";
   const idx = menuItems.findIndex((entry) => entry && entry.command === 'chatgpt.newChat');
   if (idx >= 0) {
     menuItems[idx] = {
       ...menuItems[idx],
       when: newThreadWhen,
-      group: 'navigation@2',
+      group: 'z_codexThreadActions@2',
     };
   }
 }

--- a/bin/codex-thread-renamer-patch.js
+++ b/bin/codex-thread-renamer-patch.js
@@ -94,6 +94,7 @@ function buildTarget(extensionDir) {
   const runtimeOutFile = path.join(extDir, 'out', RUNTIME_FILE);
   const webviewOutFile = path.join(webviewAssetsDir, WEBVIEW_FILE);
   const bundleFile = findWebviewBundleFile(webviewAssetsDir);
+  const webviewBundleFiles = findWebviewBundleFiles(webviewAssetsDir);
   return {
     extDir,
     packageJson,
@@ -103,6 +104,7 @@ function buildTarget(extensionDir) {
     runtimeOutFile,
     webviewOutFile,
     bundleFile,
+    webviewBundleFiles,
     runtimePatchSource: path.join(PATCHES_DIR, RUNTIME_FILE),
     webviewPatchSource: path.join(PATCHES_DIR, WEBVIEW_FILE),
   };
@@ -125,6 +127,14 @@ function findWebviewBundleFile(assetsDir) {
   return name ? path.join(assetsDir, name) : null;
 }
 
+function findWebviewBundleFiles(assetsDir) {
+  if (!fs.existsSync(assetsDir)) return [];
+  return fs.readdirSync(assetsDir)
+    .filter((n) => n.endsWith('.js') && n !== WEBVIEW_FILE)
+    .sort()
+    .map((n) => path.join(assetsDir, n));
+}
+
 function verifyTarget(target) {
   const checks = [];
   const mustExist = [
@@ -143,18 +153,26 @@ function verifyTarget(target) {
   }
 
   const extensionJs = fs.readFileSync(target.extensionJs, 'utf8');
-  const bundle = fs.readFileSync(target.bundleFile, 'utf8');
+  const webviewBundles = readExistingFiles(target.webviewBundleFiles);
   const indexHtml = fs.readFileSync(target.webviewIndexHtml, 'utf8');
   const pkg = JSON.parse(fs.readFileSync(target.packageJson, 'utf8'));
 
   checks.push(result('Signature: extension handles open-vscode-command', extensionJs.includes('case"open-vscode-command"') || extensionJs.includes('case"open-vscode-command":'), 'required for webview -> command bridge'));
   checks.push(result('Signature: extension registers webview provider', extensionJs.includes('registerWebviewViewProvider('), 'required for capturing provider'));
-  checks.push(result('Signature: webview supports thread-title-updated', bundle.includes('thread-title-updated'), 'required for live UI title update'));
-  checks.push(result('Signature: webview thread rows expose data-thread-title', bundle.includes('data-thread-title'), 'required for right-click rename hook'));
+  checks.push(result('Signature: webview supports thread-title-updated', webviewBundles.includes('thread-title-updated'), 'required for live UI title update'));
+  checks.push(result('Signature: webview thread rows expose data-thread-title', webviewBundles.includes('data-thread-title'), 'required for right-click rename hook'));
+  checks.push(result('Signature: webview exposes thread rename action', webviewBundles.includes('rename-thread'), 'required for thread action compatibility'));
   checks.push(result('Signature: webview index loads module bundle', /<script\s+type="module"[^>]*src="\.\/assets\/index-.*\.js"/.test(indexHtml), 'required to inject helper script'));
   checks.push(result('Package contributes.commands exists', Array.isArray(pkg?.contributes?.commands), 'required for adding command'));
 
   return { ok: checks.every((c) => c.ok), target, checks };
+}
+
+function readExistingFiles(files) {
+  return files
+    .filter((file) => fs.existsSync(file))
+    .map((file) => fs.readFileSync(file, 'utf8'))
+    .join('\n');
 }
 
 function inspectStatus(target) {
@@ -168,9 +186,7 @@ function inspectStatus(target) {
     try { pkg = JSON.parse(fs.readFileSync(target.packageJson, 'utf8')); } catch {}
   }
   const commandPresent = !!pkg?.contributes?.commands?.some?.((c) => c.command === 'chatgpt.renameThread');
-  const webviewMenuPresent = !!pkg?.contributes?.menus?.['webview/context']?.some?.((m) => m.command === 'chatgpt.renameThread');
   checks.push(result('Package command chatgpt.renameThread', commandPresent, 'package.json'));
-  checks.push(result('Package webview/context menu entry', webviewMenuPresent, 'package.json'));
   if (fs.existsSync(target.extensionJs)) {
     const s = fs.readFileSync(target.extensionJs, 'utf8');
     checks.push(result('extension.js runtime loader marker', s.includes(EXTENSION_JS_MARKER), 'out/extension.js'));
@@ -208,6 +224,7 @@ function patchPackageJson(file, dryRun, logs) {
   const pkg = JSON.parse(raw);
   pkg.contributes = pkg.contributes || {};
   pkg.contributes.commands = Array.isArray(pkg.contributes.commands) ? pkg.contributes.commands : [];
+  pkg.contributes.keybindings = Array.isArray(pkg.contributes.keybindings) ? pkg.contributes.keybindings : [];
   pkg.contributes.menus = pkg.contributes.menus || {};
 
   upsertCommand(pkg.contributes.commands, {
@@ -215,21 +232,48 @@ function patchPackageJson(file, dryRun, logs) {
     title: 'Rename Codex Thread',
     category: 'Codex',
   });
+  upsertCommand(pkg.contributes.commands, {
+    command: 'chatgpt.renameThreadInline',
+    title: 'Rename Thread',
+    category: 'Codex',
+  });
+  upsertCommand(pkg.contributes.commands, {
+    command: 'chatgpt.renameThreadRememberContext',
+    title: 'Remember Codex Thread Rename Context',
+    category: 'Codex',
+  });
 
   const commandPalette = ensureLiteralMenuArray(pkg.contributes.menus, 'commandPalette');
   if (!commandPalette.some((m) => m.command === 'chatgpt.renameThread')) {
     commandPalette.push({ command: 'chatgpt.renameThread' });
   }
+  upsertMenuItem(commandPalette, {
+    command: 'chatgpt.renameThreadInline',
+    when: 'false',
+  });
+  upsertMenuItem(commandPalette, {
+    command: 'chatgpt.renameThreadRememberContext',
+    when: 'false',
+  });
+
+  upsertKeybinding(pkg.contributes.keybindings, {
+    command: 'chatgpt.renameThreadInline',
+    key: 'ctrl+r',
+    mac: 'cmd+r',
+    when: "webviewId == 'chatgpt.sidebarView' || activeCustomEditorId == 'chatgpt.conversationEditor'",
+  });
+  removeKeybinding(pkg.contributes.keybindings, 'chatgpt.renameThread');
 
   cleanupLegacyNestedWebviewMenuShape(pkg.contributes.menus);
   const webviewContext = ensureLiteralMenuArray(pkg.contributes.menus, 'webview/context');
-  if (!webviewContext.some((m) => m.command === 'chatgpt.renameThread')) {
-    webviewContext.push({
-      command: 'chatgpt.renameThread',
-      when: "webviewId == 'chatgpt.sidebarView'",
-      group: 'navigation@99',
-    });
-  }
+  upsertMenuItem(webviewContext, {
+    command: 'chatgpt.renameThreadInline',
+    when: "(webviewId == 'chatgpt.sidebarView' || webviewId == 'chatgpt.sidebarSecondaryView') && codexThreadRenamer == 'thread'",
+    group: 'navigation@1',
+  });
+  preserveNewThreadMenuItem(webviewContext);
+  moveMenuItemBefore(webviewContext, 'chatgpt.renameThreadInline', 'chatgpt.newChat');
+  removeMenuItem(webviewContext, 'chatgpt.renameThread');
 
   const updated = JSON.stringify(pkg, null, 2) + '\n';
   writeIfChanged(file, raw, updated, dryRun, logs);
@@ -258,6 +302,62 @@ function upsertCommand(commands, command) {
   } else {
     commands.push(command);
   }
+}
+
+function upsertKeybinding(keybindings, keybinding) {
+  const idx = keybindings.findIndex((entry) => entry && entry.command === keybinding.command);
+  if (idx >= 0) {
+    keybindings[idx] = { ...keybindings[idx], ...keybinding };
+  } else {
+    keybindings.push(keybinding);
+  }
+}
+
+function removeKeybinding(keybindings, command) {
+  for (let i = keybindings.length - 1; i >= 0; i--) {
+    if (keybindings[i] && keybindings[i].command === command) {
+      keybindings.splice(i, 1);
+    }
+  }
+}
+
+function upsertMenuItem(menuItems, menuItem) {
+  const idx = menuItems.findIndex((entry) => entry && entry.command === menuItem.command);
+  if (idx >= 0) {
+    menuItems[idx] = { ...menuItems[idx], ...menuItem };
+  } else {
+    menuItems.push(menuItem);
+  }
+}
+
+function preserveNewThreadMenuItem(menuItems) {
+  const newThreadWhen = "(webviewId == 'chatgpt.sidebarView' || webviewId == 'chatgpt.sidebarSecondaryView') && chatgpt.supportsNewChatMenu";
+  const idx = menuItems.findIndex((entry) => entry && entry.command === 'chatgpt.newChat');
+  if (idx >= 0) {
+    menuItems[idx] = {
+      ...menuItems[idx],
+      when: newThreadWhen,
+      group: 'navigation@2',
+    };
+  }
+}
+
+function removeMenuItem(menuItems, command) {
+  for (let i = menuItems.length - 1; i >= 0; i--) {
+    if (menuItems[i] && menuItems[i].command === command) {
+      menuItems.splice(i, 1);
+    }
+  }
+}
+
+function moveMenuItemBefore(menuItems, command, beforeCommand) {
+  const from = menuItems.findIndex((entry) => entry && entry.command === command);
+  const to = menuItems.findIndex((entry) => entry && entry.command === beforeCommand);
+  if (from < 0 || to < 0 || from < to) {
+    return;
+  }
+  const [entry] = menuItems.splice(from, 1);
+  menuItems.splice(to, 0, entry);
 }
 
 function patchExtensionJs(file, dryRun, logs) {

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -51,7 +51,7 @@ The patcher injects a helper script tag into `webview/index.html`:
 
 The helper runs inside the Codex webview and adds:
 
-- `data-vscode-context` markers on thread rows so VS Code can show `Rename Thread` only there
+- `data-vscode-context` markers on thread rows so VS Code can show `Rename Thread in Codex Sidebar` only there
 - right-click context tracking for the selected thread without preventing the original menu
 - inline title editing
 - fallback command targeting when the current webview DOM does not expose a thread id

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -20,10 +20,13 @@ It also writes two injected files:
 The patcher adds:
 
 - `chatgpt.renameThread` command contribution (`Rename Codex Thread`)
+- hidden `chatgpt.renameThreadInline` helper command for webview-driven inline edits
+- hidden `chatgpt.renameThreadRememberContext` helper command for remembering the right-clicked thread
 - Command Palette entry
-- `webview/context` menu entry for the Codex sidebar webview
+- `Cmd+R` / `Ctrl+R` keybinding when the Codex sidebar or conversation editor is active
+- a context-aware `webview/context` menu item that appears only on marked Codex thread rows
 
-This makes the rename action visible in VS Code menus.
+This keeps the public command available while preserving the original Codex/VS Code context menu.
 
 ## 2) Runtime Hook (`out/extension.js`)
 
@@ -48,9 +51,10 @@ The patcher injects a helper script tag into `webview/index.html`:
 
 The helper runs inside the Codex webview and adds:
 
-- right-click menu on thread titles (`data-thread-title`)
-- `Rename Thread` action
-- prompt-based rename input
+- `data-vscode-context` markers on thread rows so VS Code can show `Rename Thread` only there
+- right-click context tracking for the selected thread without preventing the original menu
+- inline title editing
+- fallback command targeting when the current webview DOM does not expose a thread id
 
 When confirmed, the helper sends `open-vscode-command` to invoke:
 
@@ -63,6 +67,13 @@ Important:
 ## 4) Rename Command Execution
 
 When `chatgpt.renameThread` runs, it performs three layers of work.
+
+Thread targeting works like this:
+
+- If the command is invoked from a thread row context action, that thread is renamed directly.
+- If the Codex sidebar is currently inside a thread route, the runtime asks the webview for that current thread and renames it directly.
+- If a Codex conversation editor tab is active, the current thread is renamed directly.
+- If no active thread can be resolved, the command falls back to the thread picker.
 
 ### A. Backend rename (source of truth)
 
@@ -101,7 +112,10 @@ A separate helper can patch files/databases, but it cannot reliably update the l
 Before patching, `verify` checks extension signatures such as:
 
 - `open-vscode-command` handler exists in `out/extension.js`
-- webview bundle handles `thread-title-updated`
-- thread titles use `data-thread-title`
+- all webview JavaScript bundles are scanned for `thread-title-updated`
+- thread rows expose `data-thread-title`
+- the webview still exposes the built-in `rename-thread` action
+
+Injected helper bundles are excluded from signature scanning so verification only reflects the installed OpenAI extension build.
 
 If these signatures change, the patcher should fail verification rather than patching blindly.

--- a/docs/testing-and-troubleshooting.md
+++ b/docs/testing-and-troubleshooting.md
@@ -10,9 +10,14 @@
 3. Reload VS Code:
    - `Developer: Restart Extension Host` or reload window
 4. Test rename in two ways:
-   - Command Palette -> `Rename Codex Thread`
-   - Right-click a thread title -> `Rename Thread`
-5. Test persistence:
+   - Command Palette -> `Rename Codex Thread` inside a thread starts inline rename for the current thread
+   - Command Palette -> `Rename Codex Thread` outside a thread opens the thread picker
+   - Right-click a thread title -> `Rename Thread` in the original context menu
+   - `Cmd+R` / `Ctrl+R` in the Codex sidebar or conversation editor
+5. Confirm the original context menu remains available:
+   - `Rename Thread` appears above `New Thread`
+   - the existing Codex/OpenAI menu items are still present
+6. Test persistence:
    - switch threads and back
    - restart extension host
    - reopen the VS Code window
@@ -59,17 +64,17 @@ Fix:
 - Switch to another thread and back.
 - Check `Codex Thread Renamer Patch` output logs.
 
-## Cancel Prompt Shows Error Toast
+## Verify Fails After OpenAI Extension Update
 
-Current behavior:
+Likely cause:
 
-- Canceling the prompt shows `Codex rename patch: Rename cancelled.`
+- The installed OpenAI extension changed its bundled webview signatures.
 
-Status:
+Fix:
 
-- Known UX issue only (no functional failure)
-- Tracked in repo issues / changelog
-- Planned fix is to treat cancel as a silent no-op
+- Pull the latest patcher repo.
+- Run `node bin/codex-thread-renamer-patch.js verify` again before applying.
+- If verification still fails, update the verifier signatures before patching blindly.
 
 ## Useful Checks
 

--- a/docs/testing-and-troubleshooting.md
+++ b/docs/testing-and-troubleshooting.md
@@ -12,10 +12,11 @@
 4. Test rename in two ways:
    - Command Palette -> `Rename Codex Thread` inside a thread starts inline rename for the current thread
    - Command Palette -> `Rename Codex Thread` outside a thread opens the thread picker
-   - Right-click a thread title -> `Rename Thread` in the original context menu
+   - Right-click a thread title -> `Rename Thread in Codex Sidebar` in the original context menu
    - `Cmd+R` / `Ctrl+R` in the Codex sidebar or conversation editor
 5. Confirm the original context menu remains available:
-   - `Rename Thread` appears above `New Thread`
+   - `Rename Thread in Codex Sidebar` and `New Thread in Codex Sidebar` appear when right-clicking outside a thread row
+   - `Rename Thread in Codex Sidebar` appears directly above `New Thread in Codex Sidebar`
    - the existing Codex/OpenAI menu items are still present
 6. Test persistence:
    - switch threads and back

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-thread-renamer-patcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Patch the VS Code OpenAI ChatGPT/Codex extension to add live thread rename command and thread-list right-click rename.",
   "license": "MIT",

--- a/patches/codex-thread-renamer.patch.runtime.js
+++ b/patches/codex-thread-renamer.patch.runtime.js
@@ -8,6 +8,7 @@ const readline = require('readline');
 
 const PATCH_NS = '__codexThreadRenamerPatchRuntime__';
 const RUNTIME_VERSION = '0.1.0';
+const TRACE_FILE = path.join(os.tmpdir(), 'codex-thread-renamer-runtime.log');
 
 function installRuntimePatch() {
   const parent = module.parent;
@@ -28,6 +29,13 @@ function installRuntimePatch() {
     output: null,
     patchedActivate: false,
     patchedRegistrations: false,
+    webviewMessageHooked: false,
+    hookedWebviews: new WeakSet(),
+    currentThreadRequestSeq: 0,
+    pendingCurrentThreadRequests: new Map(),
+    inlineRenameRequestSeq: 0,
+    pendingInlineRenameRequests: new Map(),
+    lastContextThread: null,
   };
   globalThis[PATCH_NS] = state;
 
@@ -45,7 +53,7 @@ function installRuntimePatch() {
       // ignore
     }
   }
-  wrapActivate(parent, vscode, state);
+  tryWrapActivate(parent, vscode, state);
 }
 
 function patchProviderCapture(vscode, state) {
@@ -56,7 +64,7 @@ function patchProviderCapture(vscode, state) {
 
   const originalRegisterWebviewViewProvider = vscode.window.registerWebviewViewProvider.bind(vscode.window);
   vscode.window.registerWebviewViewProvider = function patchedRegisterWebviewViewProvider(viewType, provider, options) {
-    if (viewType === 'chatgpt.sidebarView' && provider) {
+    if ((viewType === 'chatgpt.sidebarView' || viewType === 'chatgpt.sidebarSecondaryView') && provider) {
       state.provider = provider;
     }
     return originalRegisterWebviewViewProvider(viewType, provider, options);
@@ -71,18 +79,25 @@ function patchProviderCapture(vscode, state) {
   };
 }
 
-function wrapActivate(parent, vscode, state) {
+function tryWrapActivate(parent, vscode, state) {
   if (state.patchedActivate) {
     return;
   }
-  state.patchedActivate = true;
 
-  const originalActivate = parent.exports.activate;
+  const exportsObject = parent.exports;
+  if (!exportsObject) {
+    return;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(exportsObject, 'activate');
+  const originalActivate = descriptor && typeof descriptor.get === 'function'
+    ? descriptor.get.call(exportsObject)
+    : exportsObject.activate;
   if (typeof originalActivate !== 'function') {
     return;
   }
 
-  parent.exports.activate = async function patchedActivate(context) {
+  const patchedActivate = async function patchedActivate(context) {
     const result = await originalActivate.apply(this, arguments);
     try {
       ensureOutput(vscode, state);
@@ -98,6 +113,22 @@ function wrapActivate(parent, vscode, state) {
     }
     return result;
   };
+
+  if (descriptor && descriptor.configurable) {
+    Object.defineProperty(exportsObject, 'activate', {
+      configurable: true,
+      enumerable: descriptor.enumerable !== false,
+      writable: true,
+      value: patchedActivate,
+    });
+    state.patchedActivate = true;
+    return;
+  }
+
+  if (!descriptor || descriptor.writable) {
+    exportsObject.activate = patchedActivate;
+    state.patchedActivate = true;
+  }
 }
 
 function ensureOutput(vscode, state) {
@@ -113,28 +144,43 @@ function registerRenameCommand(vscode, context, state) {
   }
   state.commandRegistered = true;
 
-  const disposable = vscode.commands.registerCommand('chatgpt.renameThread', async (args) => {
+  const renameCommands = [
+    ['chatgpt.renameThread', { mode: 'smart' }],
+    ['chatgpt.renameThreadInline', { mode: 'inline' }],
+  ].map(([commandId, options]) => vscode.commands.registerCommand(commandId, async (args) => {
     const output = ensureOutput(vscode, state);
     try {
-      await runRenameCommand(vscode, context, state, args);
+      await runRenameCommand(vscode, context, state, args, options);
     } catch (error) {
       output.appendLine(`[error] ${formatError(error)}`);
       vscode.window.showErrorMessage(`Codex rename patch: ${formatError(error)}`);
     }
+  }));
+
+  const rememberContextCommand = vscode.commands.registerCommand('chatgpt.renameThreadRememberContext', (args) => {
+    const output = ensureOutput(vscode, state);
+    const contextThread = normalizeContextThreadArgs(args);
+    state.lastContextThread = contextThread ? { ...contextThread, at: Date.now() } : null;
+    trace(output, 'remember-context-thread', state.lastContextThread);
   });
 
-  state.commandDisposable = disposable;
+  const disposables = [...renameCommands, rememberContextCommand];
+
+  state.commandDisposable = disposables;
   if (context && context.subscriptions && Array.isArray(context.subscriptions)) {
-    context.subscriptions.push(disposable);
+    for (const disposable of disposables) {
+      context.subscriptions.push(disposable);
+    }
     if (state.output) {
       context.subscriptions.push(state.output);
     }
   }
 }
 
-async function runRenameCommand(vscode, context, state, args) {
+async function runRenameCommand(vscode, context, state, args, options = { mode: 'picker' }) {
   const output = ensureOutput(vscode, state);
   ensureBinaryAvailable('sqlite3', '--version');
+  ensureWebviewMessageHook(vscode, state);
 
   const normalized = normalizeCommandArgs(args);
   const workspaceFolder = pickWorkspaceFolder(vscode);
@@ -142,6 +188,11 @@ async function runRenameCommand(vscode, context, state, args) {
   const workspaceStorageDir = findWorkspaceStorageDirForFolder(codeUserDir, workspaceFolder.uri.toString());
   const workspaceDb = path.join(workspaceStorageDir, 'state.vscdb');
   assertFileExists(workspaceDb, 'Workspace state DB not found');
+  trace(output, 'runRenameCommand:start', {
+    workspaceFolder: workspaceFolder.uri.toString(),
+    workspaceStorageDir,
+    normalized,
+  });
 
   let threads = readCodexThreadsFromWorkspaceCache(workspaceDb);
   if (threads.length === 0 && normalized.threadId) {
@@ -150,20 +201,61 @@ async function runRenameCommand(vscode, context, state, args) {
   if (threads.length === 0) {
     throw new Error('No Codex threads found in workspace cache.');
   }
+  trace(output, 'runRenameCommand:threads', {
+    count: threads.length,
+    active: threads.filter((thread) => Number(thread.status) === 2).map((thread) => ({
+      threadId: thread.threadId,
+      label: thread.label,
+      status: thread.status,
+    })),
+  });
 
-  let thread = null;
+  let resolved = null;
   if (normalized.threadId) {
-    thread = threads.find((t) => t.threadId === normalized.threadId) || {
-      threadId: normalized.threadId,
-      kind: 'local',
-      label: normalized.threadId,
-      resource: '',
+    resolved = {
+      source: 'explicit',
+      thread: threads.find((thread) => thread.threadId === normalized.threadId) || {
+        threadId: normalized.threadId,
+        kind: 'local',
+        label: normalized.threadId,
+        resource: '',
+      },
     };
+  } else if (options.mode === 'inline' || options.mode === 'smart') {
+    resolved = await resolveThreadForRename(vscode, state, normalized, threads, output);
   } else {
-    thread = await pickThread(vscode, threads);
+    resolved = {
+      source: 'picker',
+      thread: await pickThread(vscode, threads),
+    };
   }
 
+  const thread = resolved.thread;
+  if (!thread) {
+    output.appendLine('[info] rename cancelled');
+    return;
+  }
+  trace(output, 'runRenameCommand:resolved', {
+    mode: options.mode || 'picker',
+    source: resolved.source,
+    threadId: thread?.threadId || null,
+    label: thread?.label || null,
+    status: thread?.status ?? null,
+  });
+
   let newName = normalized.name;
+  const shouldStartInlineRename = !newName && resolved.source !== 'picker' && (options.mode === 'inline' || options.mode === 'smart');
+  if (shouldStartInlineRename) {
+    const startedInlineRename = await requestInlineRename(vscode, state, {
+      threadId: thread.threadId,
+      title: thread.label || '',
+    }, output);
+    if (startedInlineRename) {
+      output.appendLine('[info] inline rename started in Codex webview');
+      return;
+    }
+    throw new Error('Could not start inline rename for the selected Codex thread.');
+  }
   if (!newName) {
     newName = await promptForThreadName(vscode, thread.label || '');
     if (newName == null) {
@@ -233,6 +325,398 @@ function normalizeCommandArgs(args) {
   return { threadId: null, name: null };
 }
 
+function normalizeContextThreadArgs(args) {
+  const value = Array.isArray(args) ? args[0] : args;
+  if (!isObject(value)) return null;
+  const threadId = typeof value.threadId === 'string' ? normalizeThreadId(value.threadId, value.kind) : null;
+  if (!threadId) return null;
+  return {
+    threadId,
+    kind: typeof value.kind === 'string' && value.kind ? value.kind : 'local',
+    label: typeof value.title === 'string' && value.title ? value.title : threadId,
+    resource: typeof value.resource === 'string' ? value.resource : '',
+  };
+}
+
+function normalizeThreadId(value, kind) {
+  if (!value) return null;
+  const id = String(value).trim();
+  if (!id) return null;
+  if (kind === 'local' && id.startsWith('local:')) return id.slice('local:'.length);
+  if (kind === 'remote' && id.startsWith('remote:')) return id.slice('remote:'.length);
+  if (kind === 'pending-worktree' && id.startsWith('pending-worktree:')) return id.slice('pending-worktree:'.length);
+  if (id.startsWith('local:')) return id.slice('local:'.length);
+  if (id.startsWith('remote:')) return id.slice('remote:'.length);
+  return id;
+}
+
+async function resolveThreadForRename(vscode, state, normalized, threads, output) {
+  if (normalized.threadId) {
+    return {
+      source: 'explicit',
+      thread: threads.find((t) => t.threadId === normalized.threadId) || {
+        threadId: normalized.threadId,
+        kind: 'local',
+        label: normalized.threadId,
+        resource: '',
+      },
+    };
+  }
+
+  const contextThread = consumeRecentContextThread(state, threads, output);
+  if (contextThread) {
+    return { source: 'context-menu', thread: contextThread };
+  }
+
+  const sidebarThread = await queryCurrentSidebarThread(vscode, state, output);
+  trace(output, 'resolveThreadForRename:sidebarThread', sidebarThread);
+  if (sidebarThread) {
+    if (sidebarThread.threadId) {
+      const known = threads.find((thread) => thread.threadId === sidebarThread.threadId);
+      if (known) {
+        return { source: 'sidebar-current', thread: known };
+      }
+      return {
+        source: 'sidebar-current',
+        thread: {
+          threadId: sidebarThread.threadId,
+          kind: sidebarThread.kind || 'local',
+          label: sidebarThread.title || sidebarThread.threadId,
+          resource: sidebarThread.resource || '',
+        },
+      };
+    }
+
+    const matchedByTitle = matchSidebarThreadByTitle(sidebarThread.title, threads);
+    if (matchedByTitle) {
+      return { source: 'sidebar-current', thread: matchedByTitle };
+    }
+  }
+
+  const activeThread = findActiveThreadForRename(vscode, threads);
+  if (activeThread) {
+    trace(output, 'resolveThreadForRename:active-tab', {
+      threadId: activeThread.threadId,
+      label: activeThread.label,
+    });
+    return { source: 'active-tab', thread: activeThread };
+  }
+
+  trace(output, 'resolveThreadForRename:picker', { threadCount: threads.length });
+  return { source: 'picker', thread: await pickThread(vscode, threads) };
+}
+
+function consumeRecentContextThread(state, threads, output) {
+  const contextThread = state.lastContextThread;
+  state.lastContextThread = null;
+  if (!contextThread || !contextThread.threadId) {
+    return null;
+  }
+  const ageMs = Date.now() - Number(contextThread.at || 0);
+  if (ageMs < 0 || ageMs > 15000) {
+    trace(output, 'context-thread:expired', { threadId: contextThread.threadId, ageMs });
+    return null;
+  }
+  const known = threads.find((thread) => thread.threadId === contextThread.threadId);
+  if (known) {
+    trace(output, 'context-thread:known', { threadId: known.threadId, label: known.label, ageMs });
+    return known;
+  }
+  trace(output, 'context-thread:synthetic', { threadId: contextThread.threadId, label: contextThread.label, ageMs });
+  return {
+    threadId: contextThread.threadId,
+    kind: contextThread.kind || 'local',
+    label: contextThread.label || contextThread.threadId,
+    resource: contextThread.resource || '',
+  };
+}
+
+function matchSidebarThreadByTitle(title, threads) {
+  const normalizedTitle = normalizeThreadTitle(title);
+  if (!normalizedTitle) {
+    return null;
+  }
+
+  const exact = threads.filter((thread) => normalizeThreadTitle(thread.label) === normalizedTitle);
+  if (exact.length === 1) {
+    return exact[0];
+  }
+
+  const contains = threads.filter((thread) => {
+    const label = normalizeThreadTitle(thread.label);
+    return label && (label.includes(normalizedTitle) || normalizedTitle.includes(label));
+  });
+  if (contains.length === 1) {
+    return contains[0];
+  }
+
+  return null;
+}
+
+function normalizeThreadTitle(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+function findSingleInProgressThread(threads) {
+  const active = threads.filter((thread) => Number(thread.status) === 2);
+  return active.length === 1 ? active[0] : null;
+}
+
+function findMostRecentThread(threads) {
+  const ranked = threads
+    .filter((thread) => Number(thread.lastActivity || 0) > 0)
+    .sort((a, b) => Number(b.lastActivity || 0) - Number(a.lastActivity || 0));
+  if (ranked.length === 0) {
+    return null;
+  }
+  if (ranked.length === 1) {
+    return ranked[0];
+  }
+
+  const first = Number(ranked[0].lastActivity || 0);
+  const second = Number(ranked[1].lastActivity || 0);
+  if (first > second) {
+    return ranked[0];
+  }
+  return null;
+}
+
+function findActiveThreadForRename(vscode, threads) {
+  const activeTab = vscode.window?.tabGroups?.activeTabGroup?.activeTab || null;
+  const activeRef = extractThreadRefFromTab(activeTab);
+  if (activeRef) {
+    const known = threads.find((thread) => thread.threadId === activeRef.threadId);
+    if (known) {
+      return known;
+    }
+    return {
+      threadId: activeRef.threadId,
+      kind: activeRef.kind || 'local',
+      label: activeTab?.label || activeRef.threadId,
+      resource: activeRef.resource || '',
+    };
+  }
+
+  return null;
+}
+
+function extractThreadRefFromTab(tab) {
+  if (!tab || !tab.input) return null;
+  const input = tab.input;
+  if (typeof input.viewType === 'string' && input.viewType !== 'chatgpt.conversationEditor') {
+    return null;
+  }
+
+  const inputs = [];
+  if (input.uri) inputs.push(input.uri);
+  if (input.modified) inputs.push(input.modified);
+  if (input.original) inputs.push(input.original);
+
+  for (const candidate of inputs) {
+    const ref = extractThreadRefFromUri(candidate);
+    if (ref) {
+      return ref;
+    }
+  }
+
+  return null;
+}
+
+function extractThreadRefFromUri(uri) {
+  if (!uri) return null;
+
+  let value = '';
+  if (typeof uri === 'string') {
+    value = uri;
+  } else if (typeof uri.toString === 'function') {
+    try {
+      value = uri.toString(true);
+    } catch {
+      value = uri.toString();
+    }
+  }
+
+  if (!value) return null;
+
+  const match = value.match(/\/(local|remote)\/([^/?#]+)/);
+  if (!match) return null;
+  return {
+    kind: match[1],
+    threadId: decodeURIComponent(match[2]),
+    resource: value,
+  };
+}
+
+function ensureWebviewMessageHook(vscode, state) {
+  const provider = state.provider;
+  if (!provider) {
+    return;
+  }
+
+  const webviews = [];
+  if (provider.sidebarView?.webview) {
+    webviews.push(provider.sidebarView.webview);
+  }
+  if (provider.editorPanels && typeof provider.getWebviewForPanel === 'function') {
+    for (const panel of Array.from(provider.editorPanels.keys())) {
+      const webview = provider.getWebviewForPanel(panel);
+      if (webview) webviews.push(webview);
+    }
+  }
+
+  for (const webview of webviews) {
+    if (!webview || typeof webview.onDidReceiveMessage !== 'function') continue;
+    if (state.hookedWebviews.has(webview)) continue;
+    webview.onDidReceiveMessage((message) => {
+      handleRuntimeWebviewMessage(state, message);
+    });
+    state.hookedWebviews.add(webview);
+    state.webviewMessageHooked = true;
+  }
+}
+
+function handleRuntimeWebviewMessage(state, message) {
+  if (!message) {
+    return;
+  }
+  if (message.type === 'codex-thread-renamer/current-thread-response') {
+    const requestId = typeof message.requestId === 'number' ? message.requestId : null;
+    if (requestId == null) {
+      return;
+    }
+    const pending = state.pendingCurrentThreadRequests.get(requestId);
+    if (!pending) {
+      return;
+    }
+    state.pendingCurrentThreadRequests.delete(requestId);
+    clearTimeout(pending.timer);
+    pending.resolve(message.payload || null);
+    return;
+  }
+  if (message.type === 'codex-thread-renamer/inline-rename-response') {
+    const requestId = typeof message.requestId === 'number' ? message.requestId : null;
+    if (requestId == null) {
+      return;
+    }
+    const pending = state.pendingInlineRenameRequests.get(requestId);
+    if (!pending) {
+      return;
+    }
+    if (message.ok === true) {
+      state.pendingInlineRenameRequests.delete(requestId);
+      clearTimeout(pending.timer);
+      pending.resolve(true);
+    }
+  }
+}
+
+async function requestInlineRename(vscode, state, thread, output) {
+  ensureWebviewMessageHook(vscode, state);
+  const provider = state.provider;
+  if (!provider || typeof provider.postMessageToWebview !== 'function') {
+    return false;
+  }
+
+  const requestId = ++state.inlineRenameRequestSeq;
+  const result = await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      state.pendingInlineRenameRequests.delete(requestId);
+      resolve(false);
+    }, 1000);
+    state.pendingInlineRenameRequests.set(requestId, { resolve, timer });
+    try {
+      const sent = postMessageToKnownWebviews(provider, {
+        type: 'codex-thread-renamer/start-inline-rename',
+        requestId,
+        payload: thread,
+      }, output);
+      if (!sent) {
+        clearTimeout(timer);
+        state.pendingInlineRenameRequests.delete(requestId);
+        resolve(false);
+      }
+    } catch (error) {
+      clearTimeout(timer);
+      state.pendingInlineRenameRequests.delete(requestId);
+      if (output) {
+        output.appendLine(`[warn] inline-rename request failed: ${formatError(error)}`);
+      }
+      resolve(false);
+    }
+  });
+
+  if (output) {
+    output.appendLine(`[info] inline-rename-response=${result ? 'started' : 'not-started'}`);
+  }
+  return result;
+}
+
+function postMessageToKnownWebviews(provider, message, output) {
+  let sent = false;
+  try {
+    if (provider.sidebarView && provider.sidebarView.webview && typeof provider.postMessageToWebview === 'function') {
+      provider.postMessageToWebview(provider.sidebarView.webview, message);
+      sent = true;
+    }
+  } catch (error) {
+    if (output) output.appendLine(`[warn] sidebar webview post failed: ${formatError(error)}`);
+  }
+
+  try {
+    if (provider.editorPanels && typeof provider.getWebviewForPanel === 'function' && typeof provider.postMessageToWebview === 'function') {
+      for (const panel of Array.from(provider.editorPanels.keys())) {
+        const webview = provider.getWebviewForPanel(panel);
+        if (!webview) continue;
+        provider.postMessageToWebview(webview, message);
+        sent = true;
+      }
+    }
+  } catch (error) {
+    if (output) output.appendLine(`[warn] editor webview post failed: ${formatError(error)}`);
+  }
+
+  return sent;
+}
+
+async function queryCurrentSidebarThread(vscode, state, output) {
+  ensureWebviewMessageHook(vscode, state);
+  const provider = state.provider;
+  if (!provider || !provider.sidebarView || !provider.sidebarView.webview || typeof provider.postMessageToWebview !== 'function') {
+    return null;
+  }
+
+  const requestId = ++state.currentThreadRequestSeq;
+  const result = await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      state.pendingCurrentThreadRequests.delete(requestId);
+      resolve(null);
+    }, 700);
+    state.pendingCurrentThreadRequests.set(requestId, { resolve, timer });
+    try {
+      provider.postMessageToWebview(provider.sidebarView.webview, {
+        type: 'codex-thread-renamer/get-current-thread',
+        requestId,
+      });
+    } catch (error) {
+      clearTimeout(timer);
+      state.pendingCurrentThreadRequests.delete(requestId);
+      if (output) {
+        output.appendLine(`[warn] current-thread request failed: ${formatError(error)}`);
+      }
+      resolve(null);
+    }
+  });
+
+  if (result && output) {
+    output.appendLine(`[info] current-thread-from-sidebar=${result.threadId || 'none'}`);
+  }
+  trace(output, 'queryCurrentSidebarThread:result', result);
+  return result;
+}
+
 function pickWorkspaceFolder(vscode) {
   const folders = vscode.workspace.workspaceFolders;
   if (!folders || folders.length === 0) {
@@ -268,7 +752,11 @@ function findWorkspaceStorageDirForFolder(codeUserDir, folderUri) {
     try {
       const data = JSON.parse(fs.readFileSync(workspaceJson, 'utf8'));
       if (data && data.folder === folderUri) {
-        matches.push({ dir, mtimeMs: fs.statSync(dir).mtimeMs });
+        matches.push({
+          dir,
+          mtimeMs: fs.statSync(dir).mtimeMs,
+          score: scoreWorkspaceStorageDir(dir),
+        });
       }
     } catch {
       // ignore
@@ -278,8 +766,50 @@ function findWorkspaceStorageDirForFolder(codeUserDir, folderUri) {
   if (matches.length === 0) {
     throw new Error(`No workspaceStorage entry found for ${folderUri}`);
   }
-  matches.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  matches.sort((a, b) => {
+    if (b.score.activeCount !== a.score.activeCount) {
+      return b.score.activeCount - a.score.activeCount;
+    }
+    if (b.score.latestActivity !== a.score.latestActivity) {
+      return b.score.latestActivity - a.score.latestActivity;
+    }
+    return b.mtimeMs - a.mtimeMs;
+  });
   return matches[0].dir;
+}
+
+function scoreWorkspaceStorageDir(dir) {
+  try {
+    const dbPath = path.join(dir, 'state.vscdb');
+    if (!fs.existsSync(dbPath)) {
+      return { activeCount: 0, latestActivity: 0 };
+    }
+    const raw = readItemTableValue(dbPath, 'agentSessions.model.cache');
+    if (!raw) {
+      return { activeCount: 0, latestActivity: 0 };
+    }
+    const items = JSON.parse(raw);
+    if (!Array.isArray(items)) {
+      return { activeCount: 0, latestActivity: 0 };
+    }
+
+    let activeCount = 0;
+    let latestActivity = 0;
+    for (const item of items) {
+      if (!item || item.providerType !== 'openai-codex') continue;
+      if (Number(item.status) === 2) {
+        activeCount += 1;
+      }
+      latestActivity = Math.max(
+        latestActivity,
+        Number(item?.timing?.lastRequestStarted || 0),
+        Number(item?.timing?.created || 0)
+      );
+    }
+    return { activeCount, latestActivity };
+  } catch {
+    return { activeCount: 0, latestActivity: 0 };
+  }
 }
 
 function readCodexThreadsFromWorkspaceCache(workspaceDb) {
@@ -311,6 +841,11 @@ function readCodexThreadsFromWorkspaceCache(workspaceDb) {
       kind,
       resource,
       label: typeof item.label === 'string' && item.label ? item.label : threadId,
+      status: typeof item.status === 'number' ? item.status : null,
+      lastActivity: Math.max(
+        Number(item?.timing?.lastRequestStarted || 0),
+        Number(item?.timing?.created || 0)
+      ),
     });
   }
   return threads;
@@ -332,7 +867,7 @@ async function pickThread(vscode, threads) {
     }
   );
   if (!picked) {
-    throw new Error('Rename cancelled.');
+    return null;
   }
   return picked.thread;
 }
@@ -623,6 +1158,26 @@ function stamp() {
 function formatError(error) {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function trace(output, message, payload) {
+  const line = `[trace] ${message}${payload === undefined ? '' : ` ${safeJson(payload)}`}`;
+  if (output) {
+    output.appendLine(line);
+  }
+  try {
+    fs.appendFileSync(TRACE_FILE, `${new Date().toISOString()} ${line}\n`);
+  } catch {
+    // ignore
+  }
+}
+
+function safeJson(value) {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '"[unserializable]"';
+  }
 }
 
 class RpcClient {

--- a/patches/codex-thread-renamer.patch.webview.js
+++ b/patches/codex-thread-renamer.patch.webview.js
@@ -43,85 +43,99 @@
     return null;
   }
 
-  const MENU_ID = 'codex-thread-renamer-context-menu';
-  let menu = null;
-  let currentTarget = null;
-
-  function ensureMenu() {
-    if (menu) return menu;
-    menu = document.createElement('div');
-    menu.id = MENU_ID;
-    menu.style.position = 'fixed';
-    menu.style.zIndex = '999999';
-    menu.style.display = 'none';
-    menu.style.minWidth = '180px';
-    menu.style.padding = '6px';
-    menu.style.borderRadius = '8px';
-    menu.style.border = '1px solid rgba(128,128,128,0.35)';
-    menu.style.background = 'var(--vscode-menu-background, #1f1f1f)';
-    menu.style.boxShadow = '0 6px 24px rgba(0,0,0,0.35)';
-    menu.style.color = 'var(--vscode-menu-foreground, #fff)';
-
-    const item = document.createElement('button');
-    item.type = 'button';
-    item.textContent = 'Rename Thread';
-    item.style.display = 'block';
-    item.style.width = '100%';
-    item.style.padding = '8px 10px';
-    item.style.margin = '0';
-    item.style.border = '0';
-    item.style.borderRadius = '6px';
-    item.style.background = 'transparent';
-    item.style.color = 'inherit';
-    item.style.textAlign = 'left';
-    item.style.cursor = 'pointer';
-    item.addEventListener('mouseenter', () => {
-      item.style.background = 'var(--vscode-list-hoverBackground, rgba(255,255,255,0.08))';
-    });
-    item.addEventListener('mouseleave', () => {
-      item.style.background = 'transparent';
-    });
-    item.addEventListener('click', () => {
-      const target = currentTarget;
-      hideMenu();
-      if (!target) return;
-      openRenamePrompt(target);
-    });
-
-    menu.appendChild(item);
-    document.body.appendChild(menu);
-    return menu;
-  }
-
-  function showMenu(x, y, target) {
-    const m = ensureMenu();
-    currentTarget = target;
-    m.style.display = 'block';
-    m.style.left = '0px';
-    m.style.top = '0px';
-
-    const pad = 8;
-    const rect = m.getBoundingClientRect();
-    const maxX = Math.max(pad, window.innerWidth - rect.width - pad);
-    const maxY = Math.max(pad, window.innerHeight - rect.height - pad);
-    m.style.left = `${Math.min(maxX, Math.max(pad, x))}px`;
-    m.style.top = `${Math.min(maxY, Math.max(pad, y))}px`;
-  }
+  const THREAD_TITLE_SELECTOR = '[data-thread-title], [data-app-action-sidebar-thread-title]';
+  const THREAD_REF_SELECTOR = 'a[href*="/local/"], a[href*="/remote/"]';
+  const THREAD_ROW_SELECTOR = `${THREAD_REF_SELECTOR}, [data-app-action-sidebar-thread-row], [data-app-action-sidebar-thread-id], [data-conversation-id], [data-thread-id], [data-id], ${THREAD_TITLE_SELECTOR}`;
+  const THREAD_MARK_SELECTOR = '[data-app-action-sidebar-thread-row], [data-thread-title], [data-app-action-sidebar-thread-title]';
+  const VSCODE_CONTEXT_ATTR = 'data-vscode-context';
+  const VSCODE_CONTEXT_KEY = 'codexThreadRenamer';
+  const VSCODE_CONTEXT_VALUE = 'thread';
+  let lastKnownCurrentThread = null;
+  let lastKnownContextThread = null;
+  let inlineEditor = null;
 
   function hideMenu() {
-    if (!menu) return;
-    menu.style.display = 'none';
-    currentTarget = null;
+    // The patch uses VS Code's native webview context menu. This no-op keeps
+    // existing shortcut/blur call sites simple.
+  }
+
+  function isElementVisible(element) {
+    if (!(element instanceof Element)) return false;
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return false;
+    const style = window.getComputedStyle(element);
+    return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+  }
+
+  function closestThreadRow(start) {
+    if (!(start instanceof Element)) return null;
+
+    const direct = start.closest(THREAD_ROW_SELECTOR);
+    if (direct) {
+      return direct;
+    }
+
+    let node = start;
+    while (node && node instanceof Element && node !== document.body) {
+      if (node.querySelector) {
+        const link = node.querySelector(THREAD_REF_SELECTOR);
+        if (link) {
+          return link;
+        }
+        const attrNode = node.querySelector(THREAD_ROW_SELECTOR);
+        if (attrNode) {
+          return attrNode;
+        }
+      }
+      node = node.parentElement;
+    }
+
+    return null;
+  }
+
+  function scoreTitleNodeCandidate(element) {
+    if (!(element instanceof Element) || !isElementVisible(element)) return -1;
+    const text = String(element.textContent || '').trim();
+    if (!text || text.length > 160) return -1;
+    const rect = element.getBoundingClientRect();
+    const style = window.getComputedStyle(element);
+    const fontSize = parseFloat(style.fontSize) || 0;
+    return fontSize * 20 + rect.width * 0.05 - text.length;
+  }
+
+  function findTitleNodeInRow(row) {
+    if (!(row instanceof Element)) return null;
+    if (row.matches(THREAD_TITLE_SELECTOR)) {
+      return row;
+    }
+
+    const explicit = row.querySelector(THREAD_TITLE_SELECTOR);
+    if (explicit) {
+      return explicit;
+    }
+
+    const candidates = Array.from(row.querySelectorAll('span, div, p, strong'));
+    candidates.sort((a, b) => scoreTitleNodeCandidate(b) - scoreTitleNodeCandidate(a));
+    return candidates.find((candidate) => scoreTitleNodeCandidate(candidate) >= 0) || null;
   }
 
   function closestThreadTitleNode(start) {
-    if (!(start instanceof Element)) return null;
-    return start.closest('[data-thread-title]');
+    if (start instanceof Element) {
+      const explicit = start.closest(THREAD_TITLE_SELECTOR);
+      if (explicit) return explicit;
+    }
+    const row = closestThreadRow(start);
+    if (!row) return null;
+    return findTitleNodeInRow(row);
   }
 
-  function extractThreadInfo(titleNode) {
-    const row = titleNode.closest('a,button,[role="button"],li,div');
-    const link = titleNode.closest('a[href]') || (row && row.querySelector ? row.querySelector('a[href]') : null);
+  function extractThreadInfo(targetNode) {
+    const row =
+      (targetNode instanceof Element ? targetNode.closest('[data-app-action-sidebar-thread-row]') : null) ||
+      closestThreadRow(targetNode) ||
+      (targetNode instanceof Element ? targetNode.closest('a,button,[role="button"],li,div') : null);
+    const titleNode = findTitleNodeInRow(row) || (targetNode instanceof Element ? targetNode.closest(THREAD_TITLE_SELECTOR) : null);
+    const link = (targetNode instanceof Element ? targetNode.closest('a[href]') : null) || (row && row.querySelector ? row.querySelector('a[href]') : null);
 
     let href = '';
     if (link && link.getAttribute) href = link.getAttribute('href') || '';
@@ -136,8 +150,12 @@
       }
     }
 
+    if (row) {
+      kind = kind || normalizeKind(row.getAttribute('data-app-action-sidebar-thread-kind'));
+    }
+
     if (!threadId && row) {
-      const attrs = ['data-conversation-id', 'data-thread-id', 'data-id'];
+      const attrs = ['data-app-action-sidebar-thread-id', 'data-conversation-id', 'data-thread-id', 'data-id'];
       for (const a of attrs) {
         const v = row.getAttribute && row.getAttribute(a);
         if (v) {
@@ -147,57 +165,627 @@
       }
     }
 
-    const title = String(titleNode.textContent || '').trim();
+    threadId = normalizeThreadId(threadId, kind);
+    const title = String((titleNode && titleNode.textContent) || (row && row.textContent) || '').trim();
     return { titleNode, row, link, href, threadId, kind, title };
   }
 
-  function openRenamePrompt(target) {
+  function normalizeKind(value) {
+    const kind = String(value || '').trim();
+    return kind || null;
+  }
+
+  function normalizeThreadId(value, kind) {
+    if (!value) return null;
+    const id = String(value).trim();
+    if (!id) return null;
+    if (kind === 'local' && id.startsWith('local:')) return id.slice('local:'.length);
+    if (kind === 'remote' && id.startsWith('remote:')) return id.slice('remote:'.length);
+    if (kind === 'pending-worktree' && id.startsWith('pending-worktree:')) return id.slice('pending-worktree:'.length);
+    if (id.startsWith('local:')) return id.slice('local:'.length);
+    if (id.startsWith('remote:')) return id.slice('remote:'.length);
+    return id;
+  }
+
+  function cssEscape(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return String(value).replace(/"/g, '\\"');
+  }
+
+  function updateLiveThreadTitle(threadId, title) {
+    const normalized = normalizeThreadId(threadId, 'local');
+    if (!normalized || !title) return;
+
+    const escaped = cssEscape(normalized);
+    const selectors = [
+      `[data-app-action-sidebar-thread-id="local:${escaped}"] [data-thread-title]`,
+      `[data-app-action-sidebar-thread-id="local:${escaped}"] [data-app-action-sidebar-thread-title]`,
+      `[data-app-action-sidebar-thread-id="${escaped}"] [data-thread-title]`,
+      `[data-app-action-sidebar-thread-id="${escaped}"] [data-app-action-sidebar-thread-title]`,
+      `[data-conversation-id="${escaped}"] [data-thread-title]`,
+      `[data-thread-id="${escaped}"] [data-thread-title]`,
+    ];
+
+    for (const selector of selectors) {
+      for (const node of document.querySelectorAll(selector)) {
+        node.textContent = title;
+      }
+    }
+  }
+
+  function rememberCurrentThread(info) {
+    if (!info || !info.threadId) return;
+    lastKnownCurrentThread = {
+      threadId: info.threadId,
+      kind: info.kind || 'local',
+      resource: info.href || '',
+      title: info.title || '',
+    };
+  }
+
+  function buildThreadPayload(info) {
+    if (!info || !info.threadId) return null;
+    return {
+      threadId: info.threadId,
+      kind: info.kind || 'local',
+      resource: info.href || '',
+      title: info.title || '',
+    };
+  }
+
+  function rememberContextThread(info) {
+    const payload = buildThreadPayload(info);
+    lastKnownContextThread = payload ? { ...payload, at: Date.now() } : null;
+    if (payload) {
+      rememberCurrentThread(info);
+    }
+    return payload;
+  }
+
+  function reportContextThread(info) {
+    const payload = rememberContextThread(info);
+    if (!payload) return;
     const api = getVsCodeApi();
     if (!api) return;
+    api.postMessage({
+      type: 'open-vscode-command',
+      command: 'chatgpt.renameThreadRememberContext',
+      args: [payload],
+    });
+  }
+
+  function startInlineRenameForTarget(target) {
     const info = extractThreadInfo(target);
     if (!info.threadId) {
       console.warn('[codex-thread-renamer-patch] Could not resolve threadId from thread row', info);
+      triggerRenameCommand();
       return;
     }
-    const currentTitle = info.title || '';
-    const next = window.prompt('Rename Codex thread', currentTitle);
-    if (next == null) return;
-    const name = String(next).trim();
-    if (!name) return;
+    rememberCurrentThread(info);
+    createInlineRenameEditor({
+      threadId: info.threadId,
+      title: info.title || '',
+    }, info.titleNode || target);
+  }
 
+  function submitRename(threadId, name) {
+    const api = getVsCodeApi();
+    if (!api) return;
     api.postMessage({
       type: 'open-vscode-command',
       command: 'chatgpt.renameThread',
-      args: [{ threadId: info.threadId, name }],
+      args: [{ threadId, name }],
+    });
+  }
+
+  function shouldHandleRenameShortcut(event) {
+    if (!event || event.defaultPrevented) return false;
+    if (event.altKey || event.shiftKey) return false;
+    if (!(event.metaKey || event.ctrlKey)) return false;
+    const key = String(event.key || '').toLowerCase();
+    const code = String(event.code || '').toLowerCase();
+    if (key !== 'r' && code !== 'keyr') return false;
+
+    const target = event.target;
+    if (!(target instanceof Element)) return true;
+    if (target.closest('input, textarea, select, [contenteditable=""], [contenteditable="true"]')) {
+      return false;
+    }
+    return true;
+  }
+
+  function triggerRenameCommand() {
+    const api = getVsCodeApi();
+    if (!api) return;
+    api.postMessage({
+      type: 'open-vscode-command',
+      command: 'chatgpt.renameThreadInline',
+      args: [],
+    });
+  }
+
+  function findHeaderTitleCandidate(thread) {
+    if (!thread || (!thread.threadId && !thread.title)) return null;
+
+    const allElements = Array.from(document.querySelectorAll('h1, h2, h3, [role="heading"], div, span, p'));
+    const candidates = [];
+
+    for (const element of allElements) {
+      if (!isElementVisible(element)) continue;
+      if (element.closest('a[href*="/local/"], a[href*="/remote/"]')) continue;
+      const text = String(element.textContent || '').trim();
+      if (!text) continue;
+      if (thread.title) {
+        if (text !== thread.title) continue;
+      } else if (!text.includes(thread.threadId)) {
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      if (rect.top < 0 || rect.top > Math.min(window.innerHeight * 0.45, 240)) continue;
+      candidates.push({
+        element,
+        rect,
+        score: (parseFloat(window.getComputedStyle(element).fontSize) || 0) * 10 - rect.top,
+      });
+    }
+
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0]?.element || null;
+  }
+
+  function findThreadListTitleCandidate(thread) {
+    if (!thread) return null;
+
+    const candidates = Array.from(document.querySelectorAll('[data-thread-title]'));
+    for (const element of candidates) {
+      if (!isElementVisible(element)) continue;
+      const info = extractThreadInfo(element);
+      if (!info.threadId) continue;
+      if (thread.threadId && info.threadId === thread.threadId) {
+        return info.titleNode || element;
+      }
+    }
+
+    const rememberedTitle = String(thread.title || lastKnownCurrentThread?.title || '').trim();
+    if (!rememberedTitle) {
+      return null;
+    }
+    for (const element of candidates) {
+      if (!isElementVisible(element)) continue;
+      const text = String(element.textContent || '').trim();
+      if (text === rememberedTitle) {
+        return element;
+      }
+    }
+
+    return null;
+  }
+
+  function findInlineRenameCandidate(thread) {
+    return findThreadListTitleCandidate(thread) || findHeaderTitleCandidate(thread);
+  }
+
+  function getVisibleHeaderTitleText() {
+    const selectors = ['h1', 'h2', 'h3', '[role="heading"]', 'div', 'span', 'p'];
+    const candidates = [];
+
+    for (const selector of selectors) {
+      const elements = document.querySelectorAll(selector);
+      for (const element of elements) {
+        if (!isElementVisible(element)) continue;
+        if (element.closest('a[href*="/local/"], a[href*="/remote/"]')) continue;
+        if (element.closest('button, [role="button"]')) continue;
+
+        const text = String(element.textContent || '').trim();
+        if (!text) continue;
+        if (text.length > 120) continue;
+
+        const rect = element.getBoundingClientRect();
+        if (rect.top < 0 || rect.top > Math.min(window.innerHeight * 0.42, 220)) continue;
+        if (rect.left > Math.min(window.innerWidth * 0.5, 420)) continue;
+
+        const style = window.getComputedStyle(element);
+        const fontSize = parseFloat(style.fontSize) || 0;
+        if (fontSize < 18) continue;
+
+        candidates.push({
+          text,
+          score: fontSize * 100 - rect.top - rect.left * 0.15,
+        });
+      }
+    }
+
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates[0]?.text || '';
+  }
+
+  function destroyInlineEditor({ restoreText = true, focusTarget = true } = {}) {
+    if (!inlineEditor) return;
+    const { container, input, anchor, originalText } = inlineEditor;
+    window.removeEventListener('resize', inlineEditor.syncPosition, true);
+    window.removeEventListener('scroll', inlineEditor.syncPosition, true);
+    if (container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    if (restoreText && anchor) {
+      anchor.style.visibility = '';
+      anchor.textContent = originalText;
+    } else if (anchor) {
+      anchor.style.visibility = '';
+    }
+    if (focusTarget && anchor && typeof anchor.focus === 'function') {
+      try {
+        anchor.focus();
+      } catch {
+        // ignore
+      }
+    }
+    inlineEditor = null;
+  }
+
+  function createInlineRenameEditor(thread, titleElement) {
+    if (!thread || !thread.threadId || !titleElement) {
+      return false;
+    }
+
+    destroyInlineEditor({ restoreText: false, focusTarget: false });
+
+    const rect = titleElement.getBoundingClientRect();
+    const style = window.getComputedStyle(titleElement);
+    const container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.zIndex = '999999';
+    container.style.left = `${rect.left}px`;
+    container.style.top = `${rect.top}px`;
+    container.style.width = `${Math.max(rect.width + 24, 220)}px`;
+    container.style.maxWidth = `${Math.max(window.innerWidth - rect.left - 16, 220)}px`;
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = thread.title || titleElement.textContent || '';
+    input.setAttribute('aria-label', 'Rename Codex thread');
+    input.style.width = '100%';
+    input.style.boxSizing = 'border-box';
+    input.style.padding = '2px 6px';
+    input.style.margin = '0';
+    input.style.border = '1px solid var(--vscode-focusBorder, #007fd4)';
+    input.style.borderRadius = '4px';
+    input.style.background = 'var(--vscode-input-background, #1f1f1f)';
+    input.style.color = 'var(--vscode-input-foreground, #ffffff)';
+    input.style.font = style.font;
+    input.style.fontSize = style.fontSize;
+    input.style.fontWeight = style.fontWeight;
+    input.style.lineHeight = style.lineHeight;
+    input.style.height = `${Math.max(rect.height + 4, 28)}px`;
+    input.style.outline = 'none';
+    input.style.boxShadow = '0 0 0 1px rgba(0,0,0,0.15)';
+
+    const syncPosition = () => {
+      if (!inlineEditor || inlineEditor.input !== input) return;
+      const nextRect = titleElement.getBoundingClientRect();
+      container.style.left = `${nextRect.left}px`;
+      container.style.top = `${nextRect.top}px`;
+      container.style.width = `${Math.max(nextRect.width + 24, 220)}px`;
+      container.style.maxWidth = `${Math.max(window.innerWidth - nextRect.left - 16, 220)}px`;
+      input.style.height = `${Math.max(nextRect.height + 4, 28)}px`;
+    };
+
+    const commit = () => {
+      const next = String(input.value || '').trim();
+      if (!next) {
+        destroyInlineEditor();
+        return;
+      }
+      const unchanged = next === String(thread.title || titleElement.textContent || '').trim();
+      destroyInlineEditor({ restoreText: true, focusTarget: false });
+      if (!unchanged) {
+        submitRename(thread.threadId, next);
+      }
+    };
+
+    const cancel = () => {
+      destroyInlineEditor();
+    };
+
+    input.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        event.stopPropagation();
+        commit();
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        cancel();
+      }
+    });
+    input.addEventListener('blur', () => {
+      commit();
+    });
+
+    titleElement.style.visibility = 'hidden';
+    container.appendChild(input);
+    document.body.appendChild(container);
+    inlineEditor = {
+      container,
+      input,
+      anchor: titleElement,
+      originalText: String(titleElement.textContent || ''),
+      syncPosition,
+    };
+    window.addEventListener('resize', syncPosition, true);
+    window.addEventListener('scroll', syncPosition, true);
+    syncPosition();
+    input.focus();
+    input.select();
+    return true;
+  }
+
+  function extractThreadRefFromValue(value) {
+    if (!value) return null;
+    const match = String(value).match(/\/(local|remote)\/([^/?#]+)/);
+    if (!match) return null;
+    return {
+      kind: match[1],
+      threadId: decodeURIComponent(match[2]),
+      resource: String(value),
+    };
+  }
+
+  function extractThreadInfoFromLink(link) {
+    if (!(link instanceof Element)) return null;
+    const href = link.getAttribute('href') || '';
+    const ref = extractThreadRefFromValue(href);
+    if (!ref) return null;
+    const titleNode =
+      link.querySelector('[data-thread-title]') ||
+      link.querySelector('[data-app-action-sidebar-thread-title]') ||
+      link.closest('[data-thread-title]') ||
+      link.closest('[data-app-action-sidebar-thread-title]') ||
+      null;
+    return {
+      threadId: ref.threadId,
+      kind: ref.kind,
+      href: ref.resource,
+      title: titleNode ? String(titleNode.textContent || '').trim() : '',
+    };
+  }
+
+  function getCurrentThreadFromDom() {
+    const routeRef = extractThreadRefFromValue(window.location && window.location.href);
+    if (routeRef) {
+      const current = {
+        threadId: routeRef.threadId,
+        kind: routeRef.kind,
+        resource: routeRef.resource,
+        title: getVisibleHeaderTitleText(),
+      };
+      lastKnownCurrentThread = current;
+      return current;
+    }
+
+    const selectors = [
+      'a[aria-current="page"][href*="/local/"]',
+      'a[aria-current="page"][href*="/remote/"]',
+      'a[aria-selected="true"][href*="/local/"]',
+      'a[aria-selected="true"][href*="/remote/"]',
+      '[data-thread-title][aria-current="page"]',
+      '[data-thread-title][aria-selected="true"]',
+      '[data-thread-title][data-active="true"]',
+      '[data-app-action-sidebar-thread-row][aria-current="page"]',
+      '[data-app-action-sidebar-thread-row][aria-selected="true"]',
+      '[data-app-action-sidebar-thread-row][data-active="true"]',
+      '[data-app-action-sidebar-thread-row][data-state="active"]',
+      '[data-app-action-sidebar-thread-title][aria-current="page"]',
+      '[data-app-action-sidebar-thread-title][aria-selected="true"]',
+      '[data-app-action-sidebar-thread-title][data-active="true"]',
+    ];
+
+    for (const selector of selectors) {
+      const node = document.querySelector(selector);
+      if (!node) continue;
+      if (node.matches && node.matches('[data-thread-title], [data-app-action-sidebar-thread-row], [data-app-action-sidebar-thread-title]')) {
+        const info = extractThreadInfo(node);
+        if (info.threadId) {
+          rememberCurrentThread(info);
+          return lastKnownCurrentThread;
+        }
+      }
+      const info = extractThreadInfoFromLink(node);
+      if (info && info.threadId) {
+        rememberCurrentThread(info);
+        return lastKnownCurrentThread;
+      }
+    }
+
+    const activeLink =
+      document.querySelector('a[href*="/local/"][data-state="active"]') ||
+      document.querySelector('a[href*="/remote/"][data-state="active"]');
+    if (activeLink) {
+      const info = extractThreadInfoFromLink(activeLink);
+      if (info && info.threadId) {
+        rememberCurrentThread(info);
+        return lastKnownCurrentThread;
+      }
+    }
+
+    return lastKnownCurrentThread;
+  }
+
+  function getCurrentThreadPayload() {
+    const current = getCurrentThreadFromDom();
+    const visibleTitle = getVisibleHeaderTitleText();
+    if (!current) {
+      return null;
+    }
+    const activeTitleNode =
+      document.querySelector('[data-thread-title][aria-current="page"]') ||
+      document.querySelector('[data-thread-title][aria-selected="true"]') ||
+      document.querySelector('[data-thread-title][data-active="true"]') ||
+      document.querySelector('[data-app-action-sidebar-thread-title][aria-current="page"]') ||
+      document.querySelector('[data-app-action-sidebar-thread-title][aria-selected="true"]') ||
+      document.querySelector('[data-app-action-sidebar-thread-title][data-active="true"]') ||
+      document.querySelector('[data-app-action-sidebar-thread-row][aria-current="page"] [data-app-action-sidebar-thread-title]') ||
+      document.querySelector('[data-app-action-sidebar-thread-row][aria-selected="true"] [data-app-action-sidebar-thread-title]') ||
+      document.querySelector('[data-app-action-sidebar-thread-row][data-active="true"] [data-app-action-sidebar-thread-title]') ||
+      document.querySelector('[data-app-action-sidebar-thread-row][data-state="active"] [data-app-action-sidebar-thread-title]');
+
+    return {
+      threadId: current.threadId,
+      kind: current.kind,
+      resource: current.resource,
+      title: activeTitleNode ? String(activeTitleNode.textContent || '').trim() : (current.title || visibleTitle || ''),
+    };
+  }
+
+  function mergeVsCodeContext(element, patch) {
+    if (!(element instanceof Element)) return;
+    let context = {};
+    const raw = element.getAttribute(VSCODE_CONTEXT_ATTR);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          context = parsed;
+        }
+      } catch {
+        context = {};
+      }
+    }
+
+    let changed = false;
+    for (const [key, value] of Object.entries(patch)) {
+      if (context[key] !== value) {
+        context[key] = value;
+        changed = true;
+      }
+    }
+    if (changed || !raw) {
+      element.setAttribute(VSCODE_CONTEXT_ATTR, JSON.stringify(context));
+    }
+  }
+
+  function markThreadContextElement(element) {
+    if (!(element instanceof Element)) return;
+    const row = closestThreadRow(element) || element;
+    mergeVsCodeContext(row, { [VSCODE_CONTEXT_KEY]: VSCODE_CONTEXT_VALUE });
+    if (element !== row) {
+      mergeVsCodeContext(element, { [VSCODE_CONTEXT_KEY]: VSCODE_CONTEXT_VALUE });
+    }
+  }
+
+  function markThreadContextElements(root = document) {
+    if (root instanceof Element && root.matches(THREAD_MARK_SELECTOR)) {
+      markThreadContextElement(root);
+    }
+    const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    for (const element of scope.querySelectorAll(THREAD_MARK_SELECTOR)) {
+      markThreadContextElement(element);
+    }
+  }
+
+  let markScheduled = false;
+  function scheduleMarkThreadContextElements() {
+    if (markScheduled) return;
+    markScheduled = true;
+    requestAnimationFrame(() => {
+      markScheduled = false;
+      markThreadContextElements();
     });
   }
 
   document.addEventListener('contextmenu', (event) => {
     const titleNode = closestThreadTitleNode(event.target);
     if (!titleNode) {
-      hideMenu();
+      lastKnownContextThread = null;
       return;
     }
     const info = extractThreadInfo(titleNode);
-    if (!info.threadId) {
+    reportContextThread(info);
+  }, true);
+
+  document.addEventListener('click', (event) => {
+    const titleNode = closestThreadTitleNode(event.target);
+    if (titleNode) {
+      const info = extractThreadInfo(titleNode);
+      rememberCurrentThread(info);
+      return;
+    }
+    const link = event.target instanceof Element ? event.target.closest('a[href*="/local/"], a[href*="/remote/"]') : null;
+    if (!link) {
+      return;
+    }
+    const info = extractThreadInfoFromLink(link);
+    rememberCurrentThread(info);
+  }, true);
+
+  document.addEventListener('click', (event) => {
+    if (event.target instanceof Element && !closestThreadTitleNode(event.target)) {
+      lastKnownContextThread = null;
+    }
+  }, true);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      if (inlineEditor) {
+        event.preventDefault();
+        event.stopPropagation();
+        destroyInlineEditor();
+        return;
+      }
+      hideMenu();
+      return;
+    }
+    if (!shouldHandleRenameShortcut(event)) {
       return;
     }
     event.preventDefault();
     event.stopPropagation();
-    showMenu(event.clientX, event.clientY, titleNode);
-  }, true);
-
-  document.addEventListener('click', (event) => {
-    if (!menu || menu.style.display === 'none') return;
-    if (event.target instanceof Node && menu.contains(event.target)) return;
     hideMenu();
-  }, true);
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') hideMenu();
+    triggerRenameCommand();
   }, true);
 
   window.addEventListener('blur', hideMenu);
   window.addEventListener('resize', hideMenu);
   window.addEventListener('scroll', hideMenu, true);
+  markThreadContextElements();
+  new MutationObserver(scheduleMarkThreadContextElements).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+  window.addEventListener('message', (event) => {
+    const message = event && event.data;
+    if (!message) {
+      return;
+    }
+    if (message.type === 'thread-title-updated') {
+      updateLiveThreadTitle(message.conversationId, message.title);
+      return;
+    }
+    const api = getVsCodeApi();
+    if (!api) {
+      return;
+    }
+    if (message.type === 'codex-thread-renamer/get-current-thread') {
+      api.postMessage({
+        type: 'codex-thread-renamer/current-thread-response',
+        requestId: message.requestId,
+        payload: getCurrentThreadPayload(),
+      });
+      return;
+    }
+    if (message.type === 'codex-thread-renamer/start-inline-rename') {
+      const thread = message.payload || getCurrentThreadPayload();
+      const titleElement = findInlineRenameCandidate(thread);
+      const ok = !!(thread && titleElement && createInlineRenameEditor(thread, titleElement));
+      api.postMessage({
+        type: 'codex-thread-renamer/inline-rename-response',
+        requestId: message.requestId,
+        ok,
+      });
+    }
+  });
 })();

--- a/patches/codex-thread-renamer.patch.webview.js
+++ b/patches/codex-thread-renamer.patch.webview.js
@@ -46,12 +46,11 @@
   const THREAD_TITLE_SELECTOR = '[data-thread-title], [data-app-action-sidebar-thread-title]';
   const THREAD_REF_SELECTOR = 'a[href*="/local/"], a[href*="/remote/"]';
   const THREAD_ROW_SELECTOR = `${THREAD_REF_SELECTOR}, [data-app-action-sidebar-thread-row], [data-app-action-sidebar-thread-id], [data-conversation-id], [data-thread-id], [data-id], ${THREAD_TITLE_SELECTOR}`;
-  const THREAD_MARK_SELECTOR = '[data-app-action-sidebar-thread-row], [data-thread-title], [data-app-action-sidebar-thread-title]';
+  const THREAD_MARK_SELECTOR = `${THREAD_REF_SELECTOR}, [data-app-action-sidebar-thread-row], [data-app-action-sidebar-thread-id], [data-conversation-id], [data-thread-id], [data-thread-title], [data-app-action-sidebar-thread-title]`;
   const VSCODE_CONTEXT_ATTR = 'data-vscode-context';
   const VSCODE_CONTEXT_KEY = 'codexThreadRenamer';
   const VSCODE_CONTEXT_VALUE = 'thread';
   let lastKnownCurrentThread = null;
-  let lastKnownContextThread = null;
   let inlineEditor = null;
 
   function hideMenu() {
@@ -237,7 +236,6 @@
 
   function rememberContextThread(info) {
     const payload = buildThreadPayload(info);
-    lastKnownContextThread = payload ? { ...payload, at: Date.now() } : null;
     if (payload) {
       rememberCurrentThread(info);
     }
@@ -246,14 +244,17 @@
 
   function reportContextThread(info) {
     const payload = rememberContextThread(info);
-    if (!payload) return;
     const api = getVsCodeApi();
     if (!api) return;
     api.postMessage({
       type: 'open-vscode-command',
       command: 'chatgpt.renameThreadRememberContext',
-      args: [payload],
+      args: payload ? [payload] : [],
     });
+  }
+
+  function clearContextThread() {
+    reportContextThread(null);
   }
 
   function startInlineRenameForTarget(target) {
@@ -567,52 +568,8 @@
       return current;
     }
 
-    const selectors = [
-      'a[aria-current="page"][href*="/local/"]',
-      'a[aria-current="page"][href*="/remote/"]',
-      'a[aria-selected="true"][href*="/local/"]',
-      'a[aria-selected="true"][href*="/remote/"]',
-      '[data-thread-title][aria-current="page"]',
-      '[data-thread-title][aria-selected="true"]',
-      '[data-thread-title][data-active="true"]',
-      '[data-app-action-sidebar-thread-row][aria-current="page"]',
-      '[data-app-action-sidebar-thread-row][aria-selected="true"]',
-      '[data-app-action-sidebar-thread-row][data-active="true"]',
-      '[data-app-action-sidebar-thread-row][data-state="active"]',
-      '[data-app-action-sidebar-thread-title][aria-current="page"]',
-      '[data-app-action-sidebar-thread-title][aria-selected="true"]',
-      '[data-app-action-sidebar-thread-title][data-active="true"]',
-    ];
+    return null;
 
-    for (const selector of selectors) {
-      const node = document.querySelector(selector);
-      if (!node) continue;
-      if (node.matches && node.matches('[data-thread-title], [data-app-action-sidebar-thread-row], [data-app-action-sidebar-thread-title]')) {
-        const info = extractThreadInfo(node);
-        if (info.threadId) {
-          rememberCurrentThread(info);
-          return lastKnownCurrentThread;
-        }
-      }
-      const info = extractThreadInfoFromLink(node);
-      if (info && info.threadId) {
-        rememberCurrentThread(info);
-        return lastKnownCurrentThread;
-      }
-    }
-
-    const activeLink =
-      document.querySelector('a[href*="/local/"][data-state="active"]') ||
-      document.querySelector('a[href*="/remote/"][data-state="active"]');
-    if (activeLink) {
-      const info = extractThreadInfoFromLink(activeLink);
-      if (info && info.threadId) {
-        rememberCurrentThread(info);
-        return lastKnownCurrentThread;
-      }
-    }
-
-    return lastKnownCurrentThread;
   }
 
   function getCurrentThreadPayload() {
@@ -668,16 +625,28 @@
     }
   }
 
+  function markSidebarContextElements() {
+    const patch = { [VSCODE_CONTEXT_KEY]: VSCODE_CONTEXT_VALUE };
+    mergeVsCodeContext(document.documentElement, patch);
+    if (document.body) {
+      mergeVsCodeContext(document.body, patch);
+    }
+  }
+
   function markThreadContextElement(element) {
     if (!(element instanceof Element)) return;
     const row = closestThreadRow(element) || element;
-    mergeVsCodeContext(row, { [VSCODE_CONTEXT_KEY]: VSCODE_CONTEXT_VALUE });
-    if (element !== row) {
-      mergeVsCodeContext(element, { [VSCODE_CONTEXT_KEY]: VSCODE_CONTEXT_VALUE });
+    const title = findTitleNodeInRow(row) || (element.matches(THREAD_TITLE_SELECTOR) ? element : null);
+    const patch = { [VSCODE_CONTEXT_KEY]: VSCODE_CONTEXT_VALUE };
+    mergeVsCodeContext(row, patch);
+    mergeVsCodeContext(element, patch);
+    if (title) {
+      mergeVsCodeContext(title, patch);
     }
   }
 
   function markThreadContextElements(root = document) {
+    markSidebarContextElements();
     if (root instanceof Element && root.matches(THREAD_MARK_SELECTOR)) {
       markThreadContextElement(root);
     }
@@ -698,11 +667,13 @@
   }
 
   document.addEventListener('contextmenu', (event) => {
+    markSidebarContextElements();
     const titleNode = closestThreadTitleNode(event.target);
     if (!titleNode) {
-      lastKnownContextThread = null;
+      clearContextThread();
       return;
     }
+    markThreadContextElement(titleNode);
     const info = extractThreadInfo(titleNode);
     reportContextThread(info);
   }, true);
@@ -724,7 +695,7 @@
 
   document.addEventListener('click', (event) => {
     if (event.target instanceof Element && !closestThreadTitleNode(event.target)) {
-      lastKnownContextThread = null;
+      clearContextThread();
     }
   }, true);
 


### PR DESCRIPTION
## Summary
- updates the patcher for newer Codex/OpenAI sidebar thread markup and webview bundles
- preserves the original Codex sidebar context menu while adding `Rename Thread in Codex Sidebar`
- adds inline rename, current-thread targeting, shortcut support, and refreshed docs/changelog
- ignores local `.codex/` state so project-local checks are not published

## Verification
- `npm run verify` passed against `openai.chatgpt-26.513.21555-darwin-arm64`
- `git diff --check origin/main..HEAD` passed
- outgoing tracked files scanned for common token/secret patterns, no hits
- confirmed `.context`, `.codex/`, editor folders, private docs, and local state are not included in tracked output

## Repository security
- `main` branch protection is enabled
- PR review count: 1
- stale approvals dismissed: true
- conversation resolution required: true
- force pushes allowed: false
- deletions allowed: false
- admin enforcement: false, leaving owner emergency bypass available